### PR TITLE
Исправил ошибку валидацию контекста

### DIFF
--- a/public/metamodel/dochub/entities/contexts/plantuml.yaml
+++ b/public/metamodel/dochub/entities/contexts/plantuml.yaml
@@ -127,12 +127,12 @@ entities:
           properties:
             "dh-context-id":
               title: Идентификатор контекста
-              type: string
-              pattern: ^[0-9a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$
+              type: string              
+              pattern: ^[0-9a-zA-Z][a-zA-Z0-9_-]*(\.[0-9a-zA-Z][a-zA-Z0-9_-]*)*$
             "dh-focus-id":
               title: Идентификатор требующий подсветку
               type: string
-              pattern: ^[0-9a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$
+              pattern: ^[0-9a-zA-Z][a-zA-Z0-9_-]*(\.[0-9a-zA-Z][a-zA-Z0-9_-]*)*$
           required:
             - dh-context-id
         type: plantuml


### PR DESCRIPTION
Если идентификатор контекста имеет вид ниже, то контекст не проходит валидацию:
#L2 context
contexts:
  samolet.bu_csp.1czup:
    title: Архитектура 1С ЗУП (уровень ПА-L2)

