### PR TITLE
Исправление "съезжания" диаграмм в Firefox на широких окнах

### DIFF
--- a/src/frontend/components/Schema/PlantUML.vue
+++ b/src/frontend/components/Schema/PlantUML.vue
@@ -298,6 +298,7 @@
 .plantuml-schema svg {
   width: 100%;
   height: auto;
+  max-height: calc(100vh - 64px);
 }
 .plantuml-place {
   position: relative;


### PR DESCRIPTION
Исправление #576.

Связано с тем, что в Firefox игнорируются `height` и `width` теги на svg атрибуте. В Chrome-based браузерах выставленное `height: auto` игнорируется на svg элементе, так как перезаписывается атрибутом.

Решение немножко в лоб, но как минимум подсветит проблему и возможное решение.